### PR TITLE
Fix error caused by require_once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_401_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+          - php: '8.1'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_405_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_500_STABLE'
+            database: pgsql
+          - php: '8.3'
+            moodle-branch: 'MOODLE_501_STABLE'
+            database: mariadb
 
     steps:
       - name: Check out repository code

--- a/rule.php
+++ b/rule.php
@@ -25,7 +25,14 @@
 defined('MOODLE_INTERNAL') || die();
 
 use quizaccess_schoolyear\quiz_settings;
-require_once($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php');
+
+if (!class_exists('quiz_access_rule_base')) {
+    if (file_exists($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php')) {
+        require_once($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php');
+    } else {
+        class_alias(\mod_quiz\local\access_rule_base::class, 'quiz_access_rule_base');
+    }
+}
 
 /**
  * Implementaton of the quizaccess_schoolyear plugin.

--- a/rule.php
+++ b/rule.php
@@ -34,6 +34,10 @@ if (!class_exists('quiz_access_rule_base')) {
     }
 }
 
+if (!class_exists('quiz') && class_exists(\mod_quiz\quiz_settings::class)) {
+    class_alias(\mod_quiz\quiz_settings::class, 'quiz');
+}
+
 /**
  * Implementaton of the quizaccess_schoolyear plugin.
  */

--- a/rule.php
+++ b/rule.php
@@ -26,22 +26,19 @@ defined('MOODLE_INTERNAL') || die();
 
 use quizaccess_schoolyear\quiz_settings;
 
-if (!class_exists('quiz_access_rule_base')) {
-    if (file_exists($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php')) {
-        require_once($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php');
-    } else {
-        class_alias(\mod_quiz\local\access_rule_base::class, 'quiz_access_rule_base');
-    }
+if (!class_exists(\mod_quiz\local\access_rule_base::class)) {
+    require_once($CFG->dirroot . '/mod/quiz/accessrule/accessrulebase.php');
+    class_alias('quiz_access_rule_base', \mod_quiz\local\access_rule_base::class);
 }
 
-if (!class_exists('quiz') && class_exists(\mod_quiz\quiz_settings::class)) {
-    class_alias(\mod_quiz\quiz_settings::class, 'quiz');
+if (!class_exists(\mod_quiz\quiz_settings::class) && class_exists('quiz')) {
+    class_alias('quiz', \mod_quiz\quiz_settings::class);
 }
 
 /**
  * Implementaton of the quizaccess_schoolyear plugin.
  */
-class quizaccess_schoolyear extends quiz_access_rule_base {
+class quizaccess_schoolyear extends \mod_quiz\local\access_rule_base {
     /** Name of the plugin. */
     private const PLUGIN_NAME = 'quizaccess_schoolyear';
 
@@ -51,12 +48,12 @@ class quizaccess_schoolyear extends quiz_access_rule_base {
     /**
      * Create an instance of this rule for a particular quiz.
      *
-     * @param quiz $quizobj The quiz object.
+     * @param \mod_quiz\quiz_settings $quizobj The quiz object.
      * @param int $timenow The current time.
      * @param bool $canignoretimelimits Whether the user can ignore time limits.
      * @return self|null The rule instance or null if not applicable.
      */
-    public static function make(quiz $quizobj, $timenow, $canignoretimelimits) {
+    public static function make(\mod_quiz\quiz_settings $quizobj, $timenow, $canignoretimelimits) {
         if (empty($quizobj->get_quiz()->schoolyearenabled)) {
             return null;
         }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'quizaccess_schoolyear';
-$plugin->release = '1.0.21';
-$plugin->version = 2026021801;
+$plugin->release = '1.0.22';
+$plugin->version = 2026042101;
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
- Fix fatal error on Moodle 5.0+ caused by `require_once` of `mod/quiz/accessrule/accessrulebase.php`, which was removed in Moodle 5.0
- Added backward-compatible class resolution for `quiz_access_rule_base` and `quiz`
- Expand CI matrix to test against Moodle 4.1, 4.3, 4.4, 4.5, 5.0, and 5.1

This was tested locally : 

- Spun up Moodle 5.1 locally via [moodle-docker](https://github.com/moodlehq/moodle-docker)
- Logged in as admin, and was able to Install the plugin, no issues.
<img width="1905" height="1034" alt="Screenshot 2026-04-30 at 08 59 04" src="https://github.com/user-attachments/assets/a6ed6534-f660-45ef-a898-a9c0d35accf5" />
